### PR TITLE
Handle strings with mixed cases in `edit` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # gh-milestone
 
+## 1.1.1
+
+### Patch Changes
+
+- Strings with mixed cases are now recognized and handled in `edit` subcommand.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -8,7 +8,7 @@ import (
 	"github.com/valeriobelli/gh-milestone/internal/pkg/utils/cmdutil"
 )
 
-const version = "v1.1.0"
+const version = "v1.1.1"
 
 func Execute() {
 	var rootCommand = &cobra.Command{

--- a/internal/pkg/domain/commands/edit/state.go
+++ b/internal/pkg/domain/commands/edit/state.go
@@ -28,7 +28,9 @@ func (flag *stateFlag) GetValue() *string {
 
 func (flag *stateFlag) Set(value string) error {
 	if slices.Contains(constants.CreateMilestoneStates, strings.ToUpper(value)) {
-		*flag = stateFlag{string: &value}
+		loweredValue := strings.ToLower(value)
+
+		*flag = stateFlag{string: &loweredValue}
 
 		return nil
 	}


### PR DESCRIPTION
Closes #11